### PR TITLE
Use PlistBuddy instead of defaults in scripts

### DIFF
--- a/FraudForce SDK/build scripts/add-framework-symbols-to-app-archive.sh
+++ b/FraudForce SDK/build scripts/add-framework-symbols-to-app-archive.sh
@@ -29,7 +29,7 @@ for BUILD_FRAMEWORK_PATH in "$(find "${BUILD_FRAMEWORKS_DIR}" -name '*.framework
 	FRAMEWORK_NAME=$(basename "${BUILD_FRAMEWORK_PATH}")
 	
 	# Determine the uuids of the architectures of the executable file within the framework bundle.
-	FRAMEWORK_EXECUTABLE_NAME=$(defaults read "${BUILD_FRAMEWORK_PATH}/Info.plist" CFBundleExecutable)
+	FRAMEWORK_EXECUTABLE_NAME=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "${BUILD_FRAMEWORK_PATH}/Info.plist")
 	FRAMEWORK_EXECUTABLE_PATH="${BUILD_FRAMEWORK_PATH}/${FRAMEWORK_EXECUTABLE_NAME}"
 	EXECUTABLE_ARCHS="$(lipo -info "${FRAMEWORK_EXECUTABLE_PATH}" | rev | cut -d ':' -f1 | rev)"
 	FRAMEWORK_SLICE_UUIDS="$(xcrun dwarfdump --uuid "${FRAMEWORK_EXECUTABLE_PATH}" | awk '{ print $2 }' | tr '\n' ' ')"

--- a/FraudForce SDK/build scripts/slim-build-frameworks.sh
+++ b/FraudForce SDK/build scripts/slim-build-frameworks.sh
@@ -33,7 +33,7 @@ for UNIVERSAL_FRAMEWORK in "$(find "${INPUT_FRAMEWORKS_DIR}" -name '*.framework'
 	cp -a "${UNIVERSAL_FRAMEWORK}" "${OUTPUT_FRAMEWORKS_DIR}/."	
 	
 	# Determine the architectures of the executable file within the framework bundle.
-	FRAMEWORK_EXECUTABLE_NAME=$(defaults read "${OUTPUT_FRAMEWORK_PATH}/Info.plist" CFBundleExecutable)
+	FRAMEWORK_EXECUTABLE_NAME=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "${OUTPUT_FRAMEWORK_PATH}/Info.plist")
 	FRAMEWORK_EXECUTABLE_PATH="${OUTPUT_FRAMEWORK_PATH}/${FRAMEWORK_EXECUTABLE_NAME}"
 	EXECUTABLE_ARCHS="$(lipo -info "${FRAMEWORK_EXECUTABLE_PATH}" | rev | cut -d ':' -f1 | rev)"
 	echo "Framework (${FRAMEWORK_NAME}) executable (${FRAMEWORK_EXECUTABLE_NAME}) contains archs: ${EXECUTABLE_ARCHS}"

--- a/iovSample/bin/add-framework-symbols-to-app-archive.sh
+++ b/iovSample/bin/add-framework-symbols-to-app-archive.sh
@@ -29,7 +29,7 @@ for BUILD_FRAMEWORK_PATH in "$(find "${BUILD_FRAMEWORKS_DIR}" -name '*.framework
 	FRAMEWORK_NAME=$(basename "${BUILD_FRAMEWORK_PATH}")
 	
 	# Determine the uuids of the architectures of the executable file within the framework bundle.
-	FRAMEWORK_EXECUTABLE_NAME=$(defaults read "${BUILD_FRAMEWORK_PATH}/Info.plist" CFBundleExecutable)
+	FRAMEWORK_EXECUTABLE_NAME=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "${BUILD_FRAMEWORK_PATH}/Info.plist")
 	FRAMEWORK_EXECUTABLE_PATH="${BUILD_FRAMEWORK_PATH}/${FRAMEWORK_EXECUTABLE_NAME}"
 	EXECUTABLE_ARCHS="$(lipo -info "${FRAMEWORK_EXECUTABLE_PATH}" | rev | cut -d ':' -f1 | rev)"
 	FRAMEWORK_SLICE_UUIDS="$(xcrun dwarfdump --uuid "${FRAMEWORK_EXECUTABLE_PATH}" | awk '{ print $2 }' | tr '\n' ' ')"

--- a/iovSample/bin/slim-build-frameworks.sh
+++ b/iovSample/bin/slim-build-frameworks.sh
@@ -33,7 +33,7 @@ for UNIVERSAL_FRAMEWORK in "$(find "${INPUT_FRAMEWORKS_DIR}" -name '*.framework'
 	cp -a "${UNIVERSAL_FRAMEWORK}" "${OUTPUT_FRAMEWORKS_DIR}/."	
 	
 	# Determine the architectures of the executable file within the framework bundle.
-	FRAMEWORK_EXECUTABLE_NAME=$(defaults read "${OUTPUT_FRAMEWORK_PATH}/Info.plist" CFBundleExecutable)
+	FRAMEWORK_EXECUTABLE_NAME=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "${OUTPUT_FRAMEWORK_PATH}/Info.plist")
 	FRAMEWORK_EXECUTABLE_PATH="${OUTPUT_FRAMEWORK_PATH}/${FRAMEWORK_EXECUTABLE_NAME}"
 	EXECUTABLE_ARCHS="$(lipo -info "${FRAMEWORK_EXECUTABLE_PATH}" | rev | cut -d ':' -f1 | rev)"
 	echo "Framework (${FRAMEWORK_NAME}) executable (${FRAMEWORK_EXECUTABLE_NAME}) contains archs: ${EXECUTABLE_ARCHS}"


### PR DESCRIPTION
The defaults command will sometimes fail with an error like this:

> The domain/default pair of (.../FraudForce.framework/Info.plist, CFBundleExecutable) does not exist

The defaults command seems intended for use with the macOS preferences system. Included in its man page is:

> WARNING: The defaults command will be changed in an upcoming major release to only operate on preferences domains. General plist manipulation utilities will be folded into a different command-line program.

Perhaps Catalina is that upcoming major release 😅

A better alternative to using defaults is PlistBuddy. If you replace the defaults command in the scripts with /usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "${OUTPUT_FRAMEWORK_PATH}/Info.plist" then it will return the same value and shouldn't fail with the error quoted above.

Resolves #4